### PR TITLE
Replace string builtin modifiers with a custom API

### DIFF
--- a/src/modifiers.js
+++ b/src/modifiers.js
@@ -1,21 +1,21 @@
 const SPACE_CHAR = ' ';
 
-class Modifiers {
+const Modifiers = {
   upper(input) {
     return input.toUpperCase();
-  }
+  },
 
   lower(input) {
     return input.toLowerCase();
-  }
+  },
 
   title(input) {
     return input.toLowerCase().split(SPACE_CHAR).map(function(word) {
       return word.replace(word[0], word[0].toUpperCase());
     }).join(SPACE_CHAR);
-  }
+  },
 
-  sentence() {
+  sentence(input) {
     let output = input.toLowerCase();
     return output.replace(output[0], output[0].toUpperCase());
   }

--- a/src/registry.js
+++ b/src/registry.js
@@ -1,4 +1,5 @@
 import rule from './rule.js'
+import Modifiers from './modifiers.js'
 
 class Registry {
   constructor(rules={}) {
@@ -23,6 +24,9 @@ class Registry {
   }
 
   transform(name, value) {
+    // TODO: should this throw an error if modifier does not exist?
+    if (Modifiers[name]) return Modifiers[name](value)
+    // Still using default string methods so tests continue to pass
     return (value[name]) ? value[name]() : value
   }
 

--- a/test/grammar/interpolation-test.js
+++ b/test/grammar/interpolation-test.js
@@ -14,7 +14,7 @@ test('substitute multiple rules in a string', t => {
 test('calls formatting function in a substitution', t => {
   const g = grammar({
     start: '{hello_world}.',
-    hello_world: '{hello.toUpperCase} world',
+    hello_world: '{hello.upper} world',
     hello: 'hello'
   })
 
@@ -24,7 +24,7 @@ test('calls formatting function in a substitution', t => {
 test('calls chained formatting functions in a substitution', t => {
   const g = grammar({
     start: '{hello_world}.',
-    hello_world: '{hello.toUpperCase.trim}',
+    hello_world: '{hello.upper.trim}',
     hello: 'hello world     '
   })
 

--- a/test/modifiers-test.js
+++ b/test/modifiers-test.js
@@ -1,16 +1,22 @@
 import test from 'ava'
 import Modifiers from '../src/modifiers.js'
 
-test.beforeEach(t => {
-  t.context = {
-    modifiers: new Modifiers()
-  }
-})
-
 test('lower', t => {
-  t.is(t.context.modifiers.lower('ONE'), 'one');
+  t.is(Modifiers.lower('ONE'), 'one');
 });
 
 test('upper', t => {
-  t.is(t.context.modifiers.upper('one'), 'ONE');
+  t.is(Modifiers.upper('one'), 'ONE');
 });
+
+test('title', t => {
+  t.is(Modifiers.title('a visit from the goon squad'), 'A Visit From The Goon Squad');
+});
+
+test('sentence', t => {
+  t.is(Modifiers.sentence('a visit from the goon squad'), 'A visit from the goon squad');
+});
+// 
+// test('trim', t => {
+//   t.is(Modifiers.trim('key: value     '), 'key: value');
+// });

--- a/test/production/expression-test.js
+++ b/test/production/expression-test.js
@@ -13,13 +13,13 @@ test('evaluates a value', t => {
 })
 
 test('evaluates a value with modifier', t => {
-	const production = expression(atom, ['toUpperCase'], registry)
+	const production = expression(atom, ['upper'], registry)
 
   t.deepEqual(production.evaluate(), [Symbol.for("expression"), "HELLO"])
 })
 
 test('evaluates a value with modifier chain', t => {
-	const production = expression(atom, ['toUpperCase', 'toLowerCase'], registry)
+	const production = expression(atom, ['upper', 'lower'], registry)
 
   t.deepEqual(production.evaluate(), [Symbol.for("expression"), "hello"])
 })


### PR DESCRIPTION
⚠️ Placeholder PR while working on this feature.

Is there a better way to handle importing a library of named string formatting functions?