### PR TITLE
Add demo of indirection syntax to support ‘variable variables’

### DIFF
--- a/src/production/concat.js
+++ b/src/production/concat.js
@@ -3,6 +3,7 @@ import terminal from "./terminal.js";
 import expression from "./expression.js";
 import memo from "./memo.js";
 import unique from "./unique.js";
+import indirection from "./indirection.js";
 
 class Concat {
   constructor(expansion) {
@@ -19,12 +20,13 @@ class Concat {
   }
 }
 
-const EXPRESSION_PATTERN = /(\{[A-Za-z0-9_@$\.]+\})/;
+const EXPRESSION_PATTERN = /(\{[A-Za-z0-9_@~$\.]+\})/;
 const START_TOKEN = "{";
 const END_TOKEN = "}";
 const DEREF_TOKEN = ".";
 const MEMO_SIGIL = "@";
 const UNIQUE_SIGIL = "$";
+const INDIRECTION_SIGIL = "~";
 
 function concat(production, registry) {
   const expansion = production.split(EXPRESSION_PATTERN).map((fragment) => {
@@ -39,6 +41,8 @@ function concat(production, registry) {
         rule = memo(expr[0].slice(1, fragment.length - 1), registry);
       } else if (expr[0][0] == UNIQUE_SIGIL) {
         rule = unique(expr[0].slice(1, fragment.length - 1), registry);
+      } else if (expr[0][0] == INDIRECTION_SIGIL) {
+        rule = indirection(expr[0].slice(1, fragment.length - 1), registry);
       } else {
         rule = nonTerminal(expr[0], registry);
       }

--- a/src/production/indirection.js
+++ b/src/production/indirection.js
@@ -1,0 +1,25 @@
+import { flattenTree } from "../utils.js";
+
+class Indirection {
+  constructor(symbol, registry) {
+    this.symbol = symbol;
+    this.registry = registry;
+  }
+
+  evaluate(options) {
+    const greedySymbol = flattenTree(
+      this.registry.expand(this.symbol).evaluate(options)
+    ).join("");
+
+    return [
+      Symbol.for(this.symbol),
+      this.registry.expand(greedySymbol).evaluate(options)
+    ];
+  }
+}
+
+function indirection(symbol, registry) {
+  return new Indirection(symbol, registry);
+}
+
+export default indirection;


### PR DESCRIPTION
This adds new modifier syntax supporting a basic metaprogramming feature where the result of a template expansion is itself used as a template expansion term rather than being concatenated into the result.

eg:

```js
const varvar = calyx.grammar({
  start: "{~name} from the {~location}",
  "location": "{setting}",
  "name": "{setting}_names",
  setting: ["fantasy", "scifi", "cyberpunk"],
  fantasy: ["tower", "dungeon", "village"],
  scifi: ["starship", "mining colony", "ringworld"],
  cyberpunk: ["neon city", "pharma lab"],
  fantasy_names: ["Undin", "Mirielye", "Edhen", "Burga"],
  scifi_names: ["Raige", "Enjan", "U'Krada", "Chrotha"],
  cyberpunk_names: ["Barick", "Zechiel", "Golden Static", "Citizen Death"]
});

const result = varvar.generate();
```